### PR TITLE
メールアドレス認証機能を追加

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -67,6 +67,7 @@ func main() {
 	http.HandleFunc("/", handler)
 	http.HandleFunc("/signin", signin)
 	http.HandleFunc("/signup", signup)
+	http.HandleFunc("/checkEmail", checkEmail)
 	http.HandleFunc("/welcome", welcome)
 	http.HandleFunc("/getAnswers", processQuestionsWithAI)
 	log.Fatal(http.ListenAndServe(":8080", nil))


### PR DESCRIPTION
## What
アカウント登録をしたときにmailアドレスが有効かどうか確認する機能を追加
## Why
mail確認機能を有効にしていたのにも関わらず、確認コード入力場所がなかったため
## Who
`/checkEmail`を作成し、`username`と`verificationCode`を入力し、Emailを認証。
これにより、Emailが確認され、ログインが可能となる。
## Testing
Dockerを起動し、POSTMANなどの外部ツールを利用するか、Curlコマンドで戻り値を確認してください
```shell
# Dokerの起動
docker compose up -d --build
```

```shell
# 新規ユーザー登録
http://localhost:8080/signup
# リクエストボディ
{
  "username": "",
  "password": "",
  "email": ""
}

# AWSのデフォルトのパスワードルールを使用してるため、小文字＆大文字＆数字＆記号＆8文字以上
```
```shell
# Email確認
http://localhost:8080/checkEmail
# リクエストボディ
{
  "username": "",
  "verificationCode": ""
}
```
```shell
# ログイン
http://localhost:8080/signin
# リクエストボディ
{
  "username": "",
  "password": ""
}
```
```shell
# 認証テスト
http://localhost:8080/welcome
# 成功時
ようこそ、<username>さん
# 失敗時
なんらかのエラー
```
## Other
- 一旦`username`と`verificationCode`を受け取る設定にしているが、将来的にはusernameを保持し、確認コードだけ入力する処理に変更したい
- 確認コード再送機能の追加マスト