### PR TITLE
adminのセキュリティグループの変更とdocker-compose.ymlの変更

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,10 +1,4 @@
 services:
-  # terraform:
-  #   image: hashicorp/terraform:1.9
-  #   working_dir: /terraform
-  #   volumes:
-  #     - ./terraform:/terraform
-  #   entrypoint: ["sh", "-c", "terraform init -upgrade && terraform apply -var-file=terraform.tfvars -auto-approve"]
   api:
     build: .
     environment:

--- a/backend/terraform/docker-compose.yml
+++ b/backend/terraform/docker-compose.yml
@@ -1,0 +1,7 @@
+services:
+  terraform:
+    image: hashicorp/terraform:1.9
+    working_dir: /terraform
+    volumes:
+      - .:/terraform
+    entrypoint: ["sh", "-c", "terraform init -upgrade && terraform apply -var-file=terraform.tfvars -auto-approve"]

--- a/backend/terraform/vpc.tf
+++ b/backend/terraform/vpc.tf
@@ -121,6 +121,13 @@ resource "aws_security_group" "es-writer-admin-sg" {
 		cidr_blocks = ["0.0.0.0/0"]
 	}
 
+	ingress {
+		from_port   = 8080
+		to_port     = 8080
+		protocol    = "tcp"
+		cidr_blocks = ["0.0.0.0/0"]
+	}
+
 	egress {
 		from_port   = 443
 		to_port     = 443


### PR DESCRIPTION
## やった事
- adminのセキュリティグループに検証用の8080portインバウンドを追加
- docker-composeを分割してコメントアウトを削除

## なぜやるのか

- ELBを経由せずにEC2の起動状況を確認したかったため
- 既存の`docker-compose`だと動かしたいときにコメントアウトを消して動作させていた。その手間を省くため

## 動作確認
- それぞれ実際に動作確認済み
