### PR TITLE
feat: Add validation for HTML request in GenerateAnswers controller method

### DIFF
--- a/backend/controller/generate_controller.go
+++ b/backend/controller/generate_controller.go
@@ -1,7 +1,7 @@
 package controller
 
 import (
-	"encoding/json"
+	"es-app/model"
 	"es-app/usecase"
 	"net/http"
 
@@ -23,13 +23,16 @@ func NewGenerateController(generateUsecase usecase.IGenerateUsecase) IGenerateCo
 }
 
 func (gc *generateController) GenerateAnswers(c echo.Context) error {
-	var html string
-	err := json.NewDecoder(c.Request().Body).Decode(&html)
-	if err != nil {
+	var html model.HtmlRequest
+	if err := c.Bind(&html); err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 
-	answers, err := gc.generateUsecase.GenerateAnswers(c, html)
+	if err := c.Validate(html); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+	}
+
+	answers, err := gc.generateUsecase.GenerateAnswers(c, html.Html)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}

--- a/backend/model/generate.go
+++ b/backend/model/generate.go
@@ -26,3 +26,7 @@ type Answer struct {
 	Question string `json:"question"`
 	Answer   string `json:"answer"`
 }
+
+type HtmlRequest struct {
+	Html string `json:"html" validate:"required"`
+}


### PR DESCRIPTION
## 処理概要

- generateAnswersの受け取り方を間違えていたため修正
- 受け取り方を他の関数に合わせてechoのbindに変更
- validationも追加


## 要件・仕様

- /app/generate/generateAnswersはbodyの形式が下記のようになる
```json
{
  "html" : "{raw_html_source_code}"
}
```

## 動作確認

- postmanでポチポチ（postmanで実際に試す際は、少なくとも、HTMLの改行を無くしてダブルクォーテーションをエスケープする必要がある）
