### PR TITLE
#25 認証方法の改善

### DIFF
--- a/backend/controller/controllerUtils/controllerUtils.go
+++ b/backend/controller/controllerUtils/controllerUtils.go
@@ -27,6 +27,7 @@ func SetLoginCookie(c echo.Context, idValue string, acValue string, refValue str
 		HttpOnly: true,
 		Secure:   false,
 		SameSite: http.SameSiteStrictMode,
+		Path:     "/",
 	})
 	c.SetCookie(&http.Cookie{
 		Name:     "accessToken",
@@ -35,6 +36,7 @@ func SetLoginCookie(c echo.Context, idValue string, acValue string, refValue str
 		HttpOnly: true,
 		Secure:   false,
 		SameSite: http.SameSiteStrictMode,
+		Path:     "/",
 	})
 	c.SetCookie(&http.Cookie{
 		Name:     "refreshToken",
@@ -43,5 +45,6 @@ func SetLoginCookie(c echo.Context, idValue string, acValue string, refValue str
 		HttpOnly: true,
 		Secure:   false,
 		SameSite: http.SameSiteStrictMode,
+		Path:     "/",
 	})
 }

--- a/backend/handler/handler.go
+++ b/backend/handler/handler.go
@@ -39,7 +39,7 @@ func NewRouter(
 			userGroup.GET("/getProfile", uc.GetProfile)
 			userGroup.PATCH("/updateProfile", uc.UpdateProfile)
 		}
-		generateGroup := userGroup.Group("/generate")
+		generateGroup := appGroup.Group("/generate")
 		{
 			generateGroup.POST("/generateAnswers", gc.GenerateAnswers)
 		}

--- a/backend/middleware/auth/auth.go
+++ b/backend/middleware/auth/auth.go
@@ -3,7 +3,6 @@ package auth
 import (
 	"es-app/infrastructure"
 	"net/http"
-	"fmt"
 
 	"github.com/labstack/echo/v4"
 )

--- a/es-writer-extension/src/popup/routes/genAnswer.tsx
+++ b/es-writer-extension/src/popup/routes/genAnswer.tsx
@@ -18,7 +18,7 @@ function indexContents() {
 
           const accessToken = getCookieValue('authToken');
 
-          fetch(api_endpoint + "/app/profile/generate/generateAnswers", {
+          fetch(api_endpoint + "/app/generate/generateAnswers", {
             method: "POST",
             headers: {
               "Content-Type": "application/json",


### PR DESCRIPTION
## Issue

#25 

## 処理概要
- `middleware/auth/auth.go`内のヘッダーから取得してる部分を変更
```
- accessToken := c.Request().Header.Get("Authorization")
+ cookie, err := c.Cookie("accessToken")
```
- Cookieの設定でPathの設定が`/Auth`に設定されていたため、`/app`から読み取れなかったので設定を`/`に変更

## 要件・仕様

- HTTPヘッダーから取得してるトークンをCookieから直接取得する方法へ変更
- 

## 特記 / 特にレビューしてほしい箇所

> Cookieの設定でPathの設定が`/Auth`に設定されていたため、`/app`から読み取れなかったので設定を`/`に変更
- もしかしたらこれのせいで今までCookie読み込めてなかった説
- 軽くテストして、結局フロントから取得できなかったんだけど、もしかしたら可能性あるかも？
## 動作確認

- ローカルでフロント起動して会員登録から回答生成まで動作確認済み
- postmanで会員登録からプロフィールアップデートまで動作確認済み
