### PR TITLE
#27 ProfileFormで既存のデータを表示させる

### DIFF
--- a/backend/middleware/cors/cors.go
+++ b/backend/middleware/cors/cors.go
@@ -24,7 +24,6 @@ func SetupUserCORS() echo.MiddlewareFunc {
 			echo.HeaderOrigin,
 			echo.HeaderContentType,
 			echo.HeaderAccept,
-			echo.HeaderAuthorization,
 		},
 		AllowMethods: []string{"POST", "GET", "PATCH", "OPTIONS"},
 	})

--- a/es-writer-extension/src/components/ProfileForm.tsx
+++ b/es-writer-extension/src/components/ProfileForm.tsx
@@ -1,7 +1,6 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 
 import "../../style.css";
-import getCookieValue from "../contents/getCookieValue";
 
 import { api_endpoint } from "../contents/index"
 
@@ -10,17 +9,39 @@ const ProfileForm = () => {
   const [experience, setExperience] = useState("");
   const [projects, setProjects] = useState("");
 
+  useEffect(() => {
+    const fetchProfileData = async () => {
+      try {
+        const response = await fetch(api_endpoint + "/app/profile/getProfile", {
+          method: "GET",
+          headers: {
+            "Content-Type": "application/json",
+          }
+        });
+
+        if (response.ok) {
+          const data = await response.json();
+          setBio(data.bio || "");
+          setExperience(data.experience || "");
+          setProjects(data.projects || "");
+        } else {
+          console.error("Failed to fetch profile data");
+        }
+      } catch (error) {
+        console.error("Error fetching profile data:", error);
+      }
+    };
+
+    fetchProfileData();
+  }, []);
+
   const handleProfileSubmit = async (event: React.FormEvent) => {
     event.preventDefault();
-
-    const accessToken = getCookieValue('authToken');
-    console.log("accessToken:", accessToken);
 
     const response = await fetch(api_endpoint + "/app/profile/updateProfile", {
       method: "PATCH",
       headers: {
         "Content-Type": "application/json",
-        "Authorization": `${accessToken}` // あとで変更
       },
       body: JSON.stringify({ bio, experience, projects })
     });


### PR DESCRIPTION
## Issue
#27 
## 処理概要
- `getProfile`を用いてデータを取得
- その後Formに格納
## 要件・仕様
- `ProfileForm`で既存のデータがあった場合、画面を開いた際に表示させておく
## 特記 / 特にレビューしてほしい箇所
- なんか変なとこあったら教えて
- フロントでのクッキー取得処理は消しました
- それに伴い、`CORS`の`Authraization`受け取り許可も消しました
## 動作確認
- ローカルで起動したフロントでProfileページを開いたときに正常に取得できることを確認済み