### PR TITLE
fix:valid rule

### DIFF
--- a/es-writer-extension/src/popup/routes/checkEmail.tsx
+++ b/es-writer-extension/src/popup/routes/checkEmail.tsx
@@ -52,7 +52,9 @@ const CheckEmail = () => {
         type="text"
         placeholder="VerificationCode"
         {...register("verificationCode", {
-          required: "コードを入力してください"
+          required: "コードを入力してください",
+          minLength: { value: 6, message: "正しいコードを入力してください" },
+          maxLength: { value: 6, message: "正しいコードを入力してください" }
         })}
         className="border border-gray-300 rounded-md px-4 py-1 w-5/6"
       />

--- a/es-writer-extension/src/popup/routes/checkEmail.tsx
+++ b/es-writer-extension/src/popup/routes/checkEmail.tsx
@@ -52,9 +52,7 @@ const CheckEmail = () => {
         type="text"
         placeholder="VerificationCode"
         {...register("verificationCode", {
-          required: "Verification code is required",
-          minLength: { value: 6, message: "Minimum length is 6 characters" },
-          maxLength: { value: 6, message: "Maximum length is 6 characters" }
+          required: "コードを入力してください"
         })}
         className="border border-gray-300 rounded-md px-4 py-1 w-5/6"
       />

--- a/es-writer-extension/src/popup/routes/signIn.tsx
+++ b/es-writer-extension/src/popup/routes/signIn.tsx
@@ -44,7 +44,7 @@ const SignIn = () => {
         type="text"
         placeholder="Username"
         {...register("username", {
-          required: "Username is required"
+          required: "ユーザー名は必須です"
         })}
         className="border border-gray-300 rounded-md px-4 py-1 w-5/6"
       />
@@ -56,7 +56,7 @@ const SignIn = () => {
         type="password"
         placeholder="Password"
         {...register("password", {
-          required: "Password is required"
+          required: "パスワードは必須です"
         })}
         className="border border-gray-300 rounded-md px-4 py-1 w-5/6"
       />

--- a/es-writer-extension/src/popup/routes/signUp.tsx
+++ b/es-writer-extension/src/popup/routes/signUp.tsx
@@ -30,10 +30,11 @@ const SignUp = () => {
   // パスワードルールのチェック関数
   const checkPasswordRules = (pass) => ({
     hasNumber: /\d/.test(pass),
-    hasSpecialChar: /[!@#$%^&*]/.test(pass),
+    hasSpecialChar: /[\^$*.[\]{}()?"!@#%&\/\\,><':;|_~`=+\-]/.test(pass),
     hasUpperCase: /[A-Z]/.test(pass),
     hasLowerCase: /[a-z]/.test(pass),
-    isLongEnough: pass.length >= 8
+    isLongEnough: pass.length >= 8,
+    isAsciiPrintable: /^[\x20-\x7E]+$/.test(pass)
   })
 
   const passwordRules = checkPasswordRules(password)
@@ -66,7 +67,13 @@ const SignUp = () => {
       onSubmit={handleSubmit(onSubmit)}
       className="flex flex-col space-y-1.5 w-60 h-auto items-center mb-2 mt-2">
       <input
-        {...register("username", { required: "Username is required" })}
+        {...register("username", {
+          required: "ユーザー名は必須です",
+          pattern: {
+            value: /^[\x20-\x7E]+$/,
+            message: "使用可能文字は半角英数字・記号のみです"
+          }
+        })}
         type="text"
         placeholder="Username"
         className="border border-gray-300 rounded-md px-4 py-1 w-5/6"
@@ -77,10 +84,10 @@ const SignUp = () => {
 
       <input
         {...register("email", {
-          required: "Email is required",
+          required: "メールアドレスは必須です",
           pattern: {
             value: /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i,
-            message: "Invalid email address"
+            message: "正しいメールアドレスを入力してください"
           }
         })}
         type="text"
@@ -93,10 +100,11 @@ const SignUp = () => {
 
       <input
         {...register("password", {
-          required: "Password is required",
+          required: "パスワードは必須です",
           pattern: {
-            value: /^(?=.*\d)(?=.*[!@#$%^&*])(?=.*[a-z])(?=.*[A-Z]).{8,}$/,
-            message: "Password does not meet the requirements"
+            value:
+              /^(?=.*\d)(?=.*[\^$*.[\]{}()?"!@#%&\/\\,><':;|_~`=+\-])(?=.*[a-z])(?=.*[A-Z])[\x20-\x7E]{8,}$/,
+            message: "パスワードが不正です"
           }
         })}
         type="password"
@@ -122,6 +130,9 @@ const SignUp = () => {
         </p>
         <p className={getColorClass(passwordRules.isLongEnough)}>
           {passwordRules.isLongEnough ? "○" : "×"} 8文字以上である
+        </p>
+        <p className={getColorClass(passwordRules.isAsciiPrintable)}>
+          {passwordRules.isAsciiPrintable ? "○" : "×"} 英数字・記号のみである
         </p>
       </div>
 

--- a/es-writer-extension/src/popup/routes/signUp.tsx
+++ b/es-writer-extension/src/popup/routes/signUp.tsx
@@ -72,6 +72,10 @@ const SignUp = () => {
           pattern: {
             value: /^[\x20-\x7E]+$/,
             message: "使用可能文字は半角英数字・記号のみです"
+          },
+          maxLength: {
+            value: 20,
+            message: "ユーザー名は20文字以下にしてください"
           }
         })}
         type="text"


### PR DESCRIPTION
## Issue

#48 

## 処理概要

- パスワードはCognitoの仕様に沿った記号を使えるように
- パスワードとユーザー名通じて使用可能文字をASCII32~126までに制限
- エラーメッセージを日本語に統一
- ユーザー名を20文字に制限

## 要件・仕様

usernameとかpasswordとかにマルチバイトとかの変な文字を使えないようにする

## 特記 / 特にレビューしてほしい箇所

- エラーメッセージを日本語に統一したが、気に入らなかったら戻してOK
- ユーザー名は勝手に20文字制限入れた（長すぎるユーザー名つけられて意図しない動作したらやだし）

## 動作確認

- ローカルでフロント動作確認済み

## パフォーマンス影響

特になし、


## 参考資料

[ASCIIコード表](https://www.k-cube.co.jp/wakaba/server/ascii_code.html)